### PR TITLE
添加注释

### DIFF
--- a/LibCarla/source/carla/sensor/data/RawEpisodeState.h
+++ b/LibCarla/source/carla/sensor/data/RawEpisodeState.h
@@ -11,48 +11,51 @@
 #include "carla/sensor/data/Array.h"
 #include "carla/sensor/s11n/EpisodeStateSerializer.h"
 
+// 定义在carla命名空间下的sensor命名空间，再嵌套一个data命名空间，用于对传感器相关数据结构等进行更细分的组织
 namespace carla {
 namespace sensor {
 namespace data {
 
-  /// State of the episode at a given frame.
+  /// 表示给定帧处剧集的状态。
   class RawEpisodeState : public Array<ActorDynamicState> {
     using Super = Array<ActorDynamicState>;
   protected:
 
+ // 定义用于序列化该类数据的序列化器类型为EpisodeStateSerializer，表明使用这个序列化器来处理数据的序列化和反序列化等相关操作
     using Serializer = s11n::EpisodeStateSerializer;
 
+// 将EpisodeStateSerializer声明为友元类，这样它可以访问本类的私有成员，方便进行序列化相关操作
     friend Serializer;
 
+// 显式构造函数，接受一个右值引用的RawData类型参数，用于初始化基类Array，通过调用Serializer的header_offset和移动传入的数据来完成初始化
     explicit RawEpisodeState(RawData &&data)
       : Super(Serializer::header_offset, std::move(data)) {}
 
   private:
 
+// 获取头部信息的函数，通过调用Serializer的反序列化头部函数，传入基类的原始数据来获取相关头部信息
     auto GetHeader() const {
       return Serializer::DeserializeHeader(Super::GetRawData());
     }
 
   public:
 
-    /// Unique id of the episode at which this data was generated.
+    /// 获取生成此数据的剧集的唯一ID。
     uint64_t GetEpisodeId() const {
       return GetHeader().episode_id;
     }
 
-    /// Simulation time-stamp, simulated seconds elapsed since the beginning of
-    /// the current episode.
+    /// 模拟时间戳，即从当前剧集开始到现在经过的模拟秒数。
     double GetGameTimeStamp() const {
       return GetTimestamp();
     }
 
-    /// Time-stamp of the frame at which this measurement was taken, in seconds
-    /// as given by the OS.
+    /// 获取进行此次测量的帧的时间戳，时间单位为秒，该时间戳由操作系统提供。
     double GetPlatformTimeStamp() const {
       return GetHeader().platform_timestamp;
     }
 
-    /// Simulated seconds elapsed since previous frame.
+    /// 获取自上一帧以来经过的模拟秒数。
     double GetDeltaSeconds() const {
       return GetHeader().delta_seconds;
     }
@@ -61,7 +64,7 @@ namespace data {
       return GetHeader().map_origin;
     }
 
-    /// Simulation state flags
+    /// 获取模拟状态标志，用于表示当前模拟的一些状态情况
     Serializer::SimulationState GetSimulationState() const {
       return GetHeader().simulation_state;
     }


### PR DESCRIPTION
这段 C++ 代码定义了一个名为RawEpisodeState的类，它继承自Array<ActorDynamicState>，用于表示特定帧处剧集的相关状态信息。通过使用EpisodeStateSerializer作为序列化器，提供了一系列获取如剧集 ID、时间戳、模拟状态等各种剧集相关状态属性的方法，整体围绕着对剧集状态数据的组织、访问以及与序列化相关的操作进行设计。