### PR TITLE
# 通过install命令将变量libcarla_carla_opendrive所代表的文件列表中的所有文件， # 安装到目标安装目录（i…

### DIFF
--- a/LibCarla/cmake/server/CMakeLists.txt
+++ b/LibCarla/cmake/server/CMakeLists.txt
@@ -26,7 +26,10 @@ file(GLOB libcarla_carla_geom_headers "${libcarla_source_path}/carla/geom/*.h")
 install(FILES ${libcarla_carla_geom_headers} DESTINATION include/carla/geom)
 
 file(GLOB libcarla_carla_opendrive "${libcarla_source_path}/carla/opendrive/*.h")
-install(FILES ${libcarla_carla_opendrive} DESTINATION include/carla/opendrive)
+install(FILES ${libcarla_carla_opendrive} DESTINATION include/carla/opendrive)# 通过install命令将变量libcarla_carla_opendrive所代表的文件列表中的所有文件，
+# 安装到目标安装目录（include/carla/opendrive）下。
+# 这样在整个项目进行安装过程时，相应的头文件就能被准确放置在期望的位置，
+# 便于其他可能依赖该项目的代码在需要时能顺利找到并包含这些头文件。
 
 file(GLOB libcarla_carla_opendrive_parser "${libcarla_source_path}/carla/opendrive/parser/*.h")
 install(FILES ${libcarla_carla_opendrive_parser} DESTINATION include/carla/opendrive/parser)


### PR DESCRIPTION
…nclude/carla/opendrive）下。 # 这样在整个项目进行安装过程时，相应的头文件就能被准确放置在期望的位置， # 便于其他可能依赖该项目的代码在需要时能顺利找到并包含这些头文件。