### PR TITLE
# 使用glob模块来查找符合特定模式的文件路径。     # 这里构造的查找模式是基于当前Python的版本号以及操作系统类型来生成的。…

### DIFF
--- a/PythonAPI/util/config.py
+++ b/PythonAPI/util/config.py
@@ -19,6 +19,11 @@ import sys
 # 尝试将CARLA相关的模块路径添加到系统路径中，以便能够正确导入CARLA模块。
 # 根据当前Python版本以及操作系统类型（Windows的win-amd64或者Linux的linux-x86_64）来匹配对应的CARLA egg文件路径，并添加到系统路径。
 try:
+    # 使用glob模块来查找符合特定模式的文件路径。
+    # 这里构造的查找模式是基于当前Python的版本号以及操作系统类型来生成的。
+    # 通过格式化字符串的方式，构造出类似'../carla/dist/carla-<Python主版本号>.<Python次版本号>-<操作系统类型>.egg'这样的模式。
+    # 例如在Python 3.8的Windows系统下，模式就是'../carla/dist/carla-3.8-win-amd64.egg'。
+    # glob.glob会返回所有匹配该模式的文件路径列表，由于期望只有一个匹配的CARLA egg文件路径，所以取列表中的第一个元素（通过[0]索引获取）添加到系统路径中。
     sys.path.append(glob.glob('../carla/dist/carla-*%d.%d-%s.egg' % (
         sys.version_info.major,
         sys.version_info.minor,


### PR DESCRIPTION
…     # 通过格式化字符串的方式，构造出类似'../carla/dist/carla-<Python主版本号>.<Python次版本号>-<操作系统类型>.egg'这样的模式。     # 例如在Python 3.8的Windows系统下，模式就是'../carla/dist/carla-3.8-win-amd64.egg'。     # glob.glob会返回所有匹配该模式的文件路径列表，由于期望只有一个匹配的CARLA egg文件路径，所以取列表中的第一个元素（通过[0]索引获取）添加到系统路径中。