### PR TITLE
# 设置获取的提交深度为0，意味着获取完整的提交历史，而不是默认的浅克隆（只包含最后一次提交）# 为这个步骤命名为 "Set up Pyt…

### DIFF
--- a/.github/workflows/involvement_degree.yml
+++ b/.github/workflows/involvement_degree.yml
@@ -12,14 +12,14 @@ jobs:
           # github action 默认签出只包含最后一次提交
           # 解决方案参考：https://stackoverflow.com/questions/62334460/git-history-in-a-github-action
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - name: Set up Python
+          fetch-depth: 0# 设置获取的提交深度为0，意味着获取完整的提交历史，而不是默认的浅克隆（只包含最后一次提交）
+      - name: Set up Python # 为这个步骤命名为 "Set up Python"，主要用于在工作流的日志输出中标识这个步骤的用途
         # This is the version of the action for setting up Python, not the Python version.
         uses: actions/setup-python@v5
         with:
           python-version: '3.x' # 指定python版本
           # Optional - x64 or x86 architecture, defaults to x64
-          architecture: 'x64'
+          architecture: 'x64'# 配置Python运行的架构为x64（64位架构），这里虽然写了是可选的，但实际上如果不指定，默认也是x64架构
       - name: Install Python dependencies
         run: python -m pip install --upgrade pip requests gitpython
       - name: Display involvement degree


### PR DESCRIPTION
…hon"，主要用于在工作流的日志输出中标识这个步骤的用途.# 配置Python运行的架构为x64（64位架构），这里虽然写了是可选的，但实际上如果不指定，默认也是x64架构