### PR TITLE
// 参数说明如下： // pSdkManager：指向FbxManager对象的指针，FbxManager是FBX SDK的核心管理类，…

### DIFF
--- a/Util/DockerUtils/fbx/src/FBX2OBJ.cpp
+++ b/Util/DockerUtils/fbx/src/FBX2OBJ.cpp
@@ -132,6 +132,14 @@ bool LoadScene(
 }
 
 // Exports a scene to a file
+// SaveScene函数用于将给定的FBX场景保存为指定格式的文件
+// 它接受一系列参数来控制保存的相关设置，并根据操作结果返回成功（true）或失败（false）
+// 参数说明如下：
+// pSdkManager：指向FbxManager对象的指针，FbxManager是FBX SDK的核心管理类，用于管理整个FBX相关的资源、插件等操作，在这里作为保存场景操作的基础管理器，提供必要的上下文环境和功能支持。
+// pScene：指向FbxScene对象的指针，代表了要保存的FBX场景，包含了场景中的所有模型、动画、材质等相关数据，是实际要保存到文件中的内容主体。
+// pFilename：以字符串形式指定了要保存的文件路径及文件名，例如可以是"example.fbx"这样的形式，用于明确保存的目标位置和文件名称。
+// pFileFormat：指定了保存文件时所采用的文件格式，不同的整数值对应不同的FBX支持的格式选项，通过这个参数可以控制生成的文件格式符合特定的需求。
+// pEmbedMedia：布尔类型的参数，用于决定是否将相关的媒体资源（比如纹理图片等）嵌入到保存的FBX文件中，如果为true则嵌入，为false则不嵌入，具体取决于使用场景的需求。
 bool SaveScene(
                FbxManager* pSdkManager,
                FbxScene* pScene,


### PR DESCRIPTION
…用于管理整个FBX相关的资源、插件等操作，在这里作为保存场景操作的基础管理器，提供必要的上下文环境和功能支持。 // pScene：指向FbxScene对象的指针，代表了要保存的FBX场景，包含了场景中的所有模型、动画、材质等相关数据，是实际要保存到文件中的内容主体。 // pFilename：以字符串形式指定了要保存的文件路径及文件名，例如可以是"example.fbx"这样的形式，用于明确保存的目标位置和文件名称。 // pFileFormat：指定了保存文件时所采用的文件格式，不同的整数值对应不同的FBX支持的格式选项，通过这个参数可以控制生成的文件格式符合特定的需求。 // pEmbedMedia：布尔类型的参数，用于决定是否将相关的媒体资源（比如纹理图片等）嵌入到保存的FBX文件中，如果为true则嵌入，为false则不嵌入，具体取决于使用场景的需求。