### PR TITLE
获取当前世界的设置，可能是为了后续对比或者检查重新加载地图后设置应用的情况。获取当前世界的设置，可能是为了后续对比或者检查重新加载地图后设…

### DIFF
--- a/PythonAPI/test/smoke/test_spawnpoints.py
+++ b/PythonAPI/test/smoke/test_spawnpoints.py
@@ -26,14 +26,18 @@ class TestSpawnpoints(SyncSmokeTest):
                 # load the map
                 self.client.load_world(m)
                 # workaround: give time to UE4 to clean memory after loading (old assets)
+//由于加载地图后UE4可能需要时间清理旧资源占用的内存，所以等待5秒，
+//这是一种临时的解决办法（workaround）来确保后续操作稳定。
                 time.sleep(5)
                 
                 self.world = self.client.get_world()
 
                 # get all spawn points
+//获取当前地图的所有生成点，这些点可以用于后续生成车辆等对象
                 spawn_points = self.world.get_map().get_spawn_points()
 
                 # Check why the world settings aren't applied after a reload
+//获取当前世界的设置，可能是为了后续对比或者检查重新加载地图后设置应用的情况。
                 self.settings = self.world.get_settings()
                 settings = carla.WorldSettings(
                     no_rendering_mode=False,


### PR DESCRIPTION
…置应用的情况。