### PR TITLE
fix：No module named 'backports' in airsim 3.12, 3.13, 3.14 PythonAPI 

### DIFF
--- a/PythonAPI/test/requirements.txt
+++ b/PythonAPI/test/requirements.txt
@@ -3,4 +3,5 @@ numpy
 msgpack-rpc-python
 nose2
 # pygame
-# backports
+backports.weakref
+backports.ssl_match_hostname

--- a/Util/BuildTools/Check.bat
+++ b/Util/BuildTools/Check.bat
@@ -202,11 +202,12 @@ rem ============================================================================
 :: AIR_TESTS
 if %AIR_TESTS%==true (
     echo Running Carla-Air example tests...
-    for /l %%i in (11,-1,7) do (
+    for /l %%i in (14,-1,7) do (
         echo Running Carla-Air Python API for Python.%%i example tests.
         call conda activate hutb_3.%%i
         cd %ROOT_PATH:/=\%PythonAPI\examples\air\
-        rem python 3.7 - 3.11 is normal, but 3.12, 3.13, 3.14 is abnormal: No module named 'backports'
+        rem AirSim: python 3.7 - 3.11 is normal, but 3.12, 3.13, 3.14 is abnormal: No module named 'backports'
+        rem requirements: backports.weakref, backports.ssl_match_hostname
         python 01_hello_world.py --port 3654
         python 02_weather_control.py --port 3654
         python 03_spawn_traffic.py --port 3654


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux and ue4-dev)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
