### PR TITLE
[Content] 修复巴塞罗那自治大学场景生成点测试中的生成冲突、生成后与生成点发生偏差的问题 & 复制代码导致测试y的偏差和x的偏差一样

### DIFF
--- a/PythonAPI/test/smoke/test_spawnpoints.py
+++ b/PythonAPI/test/smoke/test_spawnpoints.py
@@ -23,7 +23,7 @@ class TestSpawnpoints(SyncSmokeTest):
         blueprints = self.filter_vehicles_for_old_towns(blueprints)
 
         # get all available maps: 
-        maps = ['Town01', 'Town01_Opt', 'Town02', 'Town02_Opt', 'Town03', 'Town03_Opt', 'Town04', 'Town04_Opt', 'Town05', 'Town05_Opt', 'Town06', 'Town06_Opt', 'Town07', 'Town07_Opt', 'Town10HD', 'Town10HD_Opt']
+        maps = ['Town01', 'Town01_Opt', 'Town02', 'Town02_Opt', 'Town03', 'Town03_Opt', 'Town04', 'Town04_Opt', 'Town05', 'Town05_Opt', 'Town06', 'Town06_Opt', 'Town07', 'Town07_Opt', 'Town10HD', 'Town10HD_Opt', 'Town15']
         for m in maps:
             # load the map
             self.client.load_world(m)
@@ -131,11 +131,11 @@ class TestSpawnpoints(SyncSmokeTest):
                             )
                         )
                         self.assertAlmostEqual(
-                            t0.location.x, t1.location.x, places=2,
+                            t0.location.y, t1.location.y, places=2,
                             msg=(
                                 "Y position mismatch.\n"
                                 f"actor_id={actor_id}\n"
-                                f"{TestSpawnpoints.diff_msg('x', t0.location.y, t1.location.y)}"
+                                f"{TestSpawnpoints.diff_msg('y', t0.location.y, t1.location.y)}"
                             )
                         )
                         self.assertAlmostEqual(


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux and ue4-dev)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

加入Town15的生成点测试功能，相关资产的更新：https://git.code.tencent.com/OpenHUTB/Content/commit/8598c436cf1ba7b6573da8692b49fca3cf45585f

#### Where has this been tested?

  * **Platform(s):** win11
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
