### PR TITLE
[carla] Fix segfault on LaneCrossingCalculator nullptr access- #9591

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
  * Added support for parsing offsets from OpenDRIVE using optional offset transforms.
  * Added ad-rss type-stubs for the PythonAPI when building with RSS support
  * Make TrafficManager PID controller use actual delta times to improve robustness to different fixed_delta_seconds
+ * Fix segfault on LaneCrossingCalculator nullptr access
 
 
 ## CARLA 0.9.16

--- a/LibCarla/source/carla/road/element/LaneCrossingCalculator.cpp
+++ b/LibCarla/source/carla/road/element/LaneCrossingCalculator.cpp
@@ -38,15 +38,23 @@ namespace element {
 
     if (dest_is_at_right) {
       if (w0_is_offroad) {
-        return { LaneMarking(*w1_marks.second) };
+        if ( w1_marks.second != nullptr ) {
+          return { LaneMarking(*w1_marks.second) };
+        }
       } else {
-        return { LaneMarking(*w0_marks.first) };
+        if ( w0_marks.first != nullptr ) {
+          return { LaneMarking(*w0_marks.first) };
+        }
       }
     } else {
       if (w0_is_offroad) {
-        return { LaneMarking(*w1_marks.first) };
+        if ( w1_marks.first != nullptr ) {
+          return { LaneMarking(*w1_marks.first) };
+        }
       } else {
-        return { LaneMarking(*w0_marks.second) };
+        if ( w0_marks.second != nullptr ) {
+          return { LaneMarking(*w0_marks.second) };
+        }
       }
     }
 


### PR DESCRIPTION
#9591

LaneCrossingCalculator tried to create LaneMarking objects without check if the respective information object exists at all.

Description
Running manual_control.py on a custom made map showed segfaults. Debugging lead to a nullptr access on the not existing information from the map. OpenDRIVE maps are valid even without lane marking information (or with a reduced set of it). This change prevents from the segfault an just returns an empty list of markings.

Fixes #

Where has this been tested?
Platform(s): ... Ubuntu 24.04
Python version(s): ... 3.12
Unreal Engine version(s): ... 4.26


