### PR TITLE
solve missing UnrealBuildTool/UnrealBuildTool.exe

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -9,6 +9,8 @@ set skip_prerequisites=false
 set launch=false
 rem launch editor directly, used for quick test after build/package
 set direct_launch=false
+rem to solve the issue of "Missing D:/hutb/Build/engine/Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.exe after build" when generate CarlaUE4.sln according to CarlaUE4.uproject
+set generate_project_files=false
 set package=false
 set interactive=false
 set python_path=python
@@ -63,6 +65,8 @@ rem -- PARSE COMMAND LINE ARGUMENTS --
         set package=true
     ) else if "%1"=="--launch" (
         set launch=true
+    ) else if "%1"=="-g" (
+        set generate_project_files=true
     ) else if "%1"=="-l" (
         set launch=true
     ) else if "%1"=="-d" (
@@ -92,6 +96,11 @@ rem -- MAIN --
 
 :main
 
+if %generate_project_files% == true (
+    echo Generating project files...
+    rem --engine is rquired to display the Plugin in the Unreal Editor, otherwise the plugin will be hidden in the editor
+    call "%UE4_ROOT%\Engine\Build\BatchFiles\GenerateProjectFiles.bat" -project="%scriptDir%\Unreal\CarlaUE4\CarlaUE4.uproject" -game -engine -progress || exit /b
+)
 
 rem if direct_launch is true, skip all the setup and launch game directly, used for quick test after build/package
 if %direct_launch% == true (


### PR DESCRIPTION
…ET/UnrealBuildTool/UnrealBuildTool.exe after build" when generate CarlaUE4.sln according to CarlaUE4.uproject

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux and ue4-dev)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
